### PR TITLE
Fixed missing byte from rebuilt documents

### DIFF
--- a/c-icap-modules/services/gw_rebuild/gw_body.c
+++ b/c-icap-modules/services/gw_rebuild/gw_body.c
@@ -3,21 +3,9 @@
 #include "../../common.h"
 #include <assert.h>
 
-void gw_body_data_new(gw_body_data_t *bd, enum gw_body_type type, int size)
+void gw_body_data_new(gw_body_data_t *bd, int size)
 {
-    if (type == GW_BT_FILE) {
-        bd->store.file = ci_simple_file_new(size);
-        if (bd->store.file)
-            bd->type = type;
-    }
-    else if (type == GW_BT_MEM) {
-        bd->store.mem = ci_membuf_new_sized(size);
-        if (bd->store.mem)
-            bd->type = type;
-    }
-    else
-        bd->type = GW_BT_NONE;
-    
+    bd->store = ci_simple_file_new(size);   
     bd->rebuild = ci_simple_file_new(0);
     bd->buf_exceed = 0;
     bd->decoded = NULL;
@@ -25,29 +13,15 @@ void gw_body_data_new(gw_body_data_t *bd, enum gw_body_type type, int size)
 
 void gw_body_data_named(gw_body_data_t *bd, const char *dir, const char *name)
 {
-    bd->store.file = ci_simple_file_named_new((char *)dir, (char *)name, 0);
-    if (bd->store.file)
-        bd->type = GW_BT_FILE;
-    else
-        bd->type = GW_BT_NONE;
-
+    bd->store = ci_simple_file_named_new((char *)dir, (char *)name, 0);
     bd->buf_exceed = 0;
 }
 
 void gw_body_data_destroy(gw_body_data_t *body)
 {
-    if (body->type == GW_BT_NONE)
-        return; /*Nothing to do*/
-    if (body->type == GW_BT_FILE) {
-        ci_simple_file_destroy(body->store.file);
-        body->store.file = NULL;
-        body->type = GW_BT_NONE;
-    }
-    else if (body->type == GW_BT_MEM) {
-        ci_membuf_free(body->store.mem);
-        body->store.mem = NULL;
-        body->type = GW_BT_NONE;
-    }
+    ci_simple_file_destroy(body->store);
+    body->store = NULL;
+
     if (body->decoded) {
         ci_simple_file_destroy(body->decoded);
         body->decoded = NULL;
@@ -60,16 +34,10 @@ void gw_body_data_destroy(gw_body_data_t *body)
 
 void gw_body_data_release(gw_body_data_t *body)
 {
-    /*This is make sense only for ci_simple_file_t objects.
-      Means that the file will be closed but not removed from disk
-      It is used only in vir_mode.
-     */
-    assert(body->type == GW_BT_FILE);
-    ci_simple_file_release(body->store.file);
-    body->store.file = NULL;
+    ci_simple_file_release(body->store);
+    body->store = NULL;
     ci_simple_file_release(body->rebuild);
     
-    body->type = GW_BT_NONE;
     if (body->decoded) {
         ci_simple_file_destroy(body->decoded);
         body->decoded = NULL;
@@ -78,37 +46,18 @@ void gw_body_data_release(gw_body_data_t *body)
 
 int gw_body_data_write(gw_body_data_t *body, char *buf, int len, int iseof)
 {
-    int memsize;
-    if (body->type == GW_BT_FILE)
-        return ci_simple_file_write(body->store.file, buf, len, iseof);
-    else if (body->type == GW_BT_MEM) {
-        if (body->buf_exceed)
-            return 0; /*or just consume everything?*/
-        memsize = body->store.mem->bufsize - body->store.mem->endpos;
-        if (memsize < len) {
-            body->buf_exceed = 1;
-            return 0;
-        }
-        return ci_membuf_write(body->store.mem, buf, len, iseof);
-    }
-    return 0;
+    return ci_simple_file_write(body->store, buf, len, iseof);
 }
 
 int gw_body_data_read(gw_body_data_t *body, char *buf, int len)
 {
-    if (body->type == GW_BT_FILE)
-        return ci_simple_file_read(body->store.file, buf, len);
-    else if (body->type == GW_BT_MEM)
-        return ci_membuf_read(body->store.mem, buf, len);
-    return 0;
+    return ci_simple_file_read(body->store, buf, len);
 }
 
 void gw_body_data_replace_body(gw_body_data_t *body, char *buf, int len)
 {
-	int bt;
-	bt = body->type;
 	gw_body_data_destroy(body);
-	gw_body_data_new(body, bt, len);
+	gw_body_data_new(body, len);
 	gw_body_data_write(body, buf, len, 1);	
 }
 

--- a/c-icap-modules/services/gw_rebuild/gw_body.h
+++ b/c-icap-modules/services/gw_rebuild/gw_body.h
@@ -6,23 +6,19 @@
 enum gw_body_type {GW_BT_NONE=0, GW_BT_FILE, GW_BT_MEM};
 
 typedef struct gw_body_data {
-    union {
-        ci_simple_file_t *file;
-        ci_membuf_t *mem;
-    } store;
+    ci_simple_file_t *store;
     ci_simple_file_t* rebuild;
     int buf_exceed;
     ci_simple_file_t *decoded;
-    enum gw_body_type type;
 } gw_body_data_t;
 
-#define gw_body_data_lock_all(bd) (void)((bd)->type == GW_BT_FILE && (ci_simple_file_lock_all((bd)->store.file)))
-#define gw_body_data_unlock(bd, len) (void)((bd)->type == GW_BT_FILE && (ci_simple_file_unlock((bd)->store.file, len)))
-#define gw_body_data_unlock_all(bd) (void)((bd)->type == GW_BT_FILE && (ci_simple_file_unlock_all((bd)->store.file)))
-#define gw_body_data_size(bd) ((bd)->type == GW_BT_FILE ? (bd)->store.file->endpos : ((bd)->type == GW_BT_MEM ? (bd)->store.mem->endpos : 0))
+#define gw_body_data_lock_all(bd) (void)(ci_simple_file_lock_all((bd)->store))
+#define gw_body_data_unlock(bd, len) (void)(ci_simple_file_unlock((bd)->store, len))
+#define gw_body_data_unlock_all(bd) (void)(ci_simple_file_unlock_all((bd)->store))
+#define gw_body_data_size(bd) ((bd)->store->endpos)
 #define gw_body_rebuild_size(bd) ((bd)->rebuild->endpos)
 
-void gw_body_data_new(gw_body_data_t *bd, enum gw_body_type type,  int size);
+void gw_body_data_new(gw_body_data_t *bd, int size);
 void gw_body_data_named(gw_body_data_t *bd, const char *dir, const char *name);
 void gw_body_data_destroy(gw_body_data_t *body);
 void gw_body_data_release(gw_body_data_t *body);

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -201,7 +201,6 @@ static void *gw_rebuild_init_request_data(ci_request_t *req)
         data->url_log[0] = '\0';
         data->gw_status = GW_STATUS_UNDEFINED;
         data->gw_processing = GW_PROCESSING_UNDEFINED;
-        data->must_scanned = SCAN;
         if (ALLOW204)
             data->args.enable204 = 1;
         else

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -299,10 +299,7 @@ int gw_rebuild_write_to_net(char *buf, int len, ci_request_t *req)
     if (!data)
         return CI_ERROR;
 
-    if(data->body.type != GW_BT_NONE)
-        bytes = gw_body_data_read(&data->body, buf, len);
-    else
-        bytes =0;
+    bytes = gw_body_data_read(&data->body, buf, len);
 
     ci_debug_printf(9, "gw_rebuild_write_to_net; write bytes is %d\n", bytes);
 
@@ -313,23 +310,20 @@ int gw_rebuild_read_from_net(char *buf, int len, int iseof, ci_request_t *req)
 {
     ci_debug_printf(9, "gw_rebuild_read_from_net; buf len is %d, iseof is %d\n", len, iseof);
 
-     gw_rebuild_req_data_t *data = ci_service_data(req);
-     if (!data)
-          return CI_ERROR;
-
-     if (data->body.type == GW_BT_NONE) /*No body data? consume all content*/
-        return len;
-
-     if (data->args.sizelimit
-         && gw_body_data_size(&data->body) >= data->max_object_size) {
-         ci_debug_printf(2, "Object bigger than max scanable file. \n");
-
-        /*TODO: Raise an error report rather than just raise an error */
+    gw_rebuild_req_data_t *data = ci_service_data(req);
+    if (!data)
         return CI_ERROR;
-     } 
-     ci_debug_printf(9, "gw_rebuild_read_from_net:Writing to data->body, %d bytes \n", len);
 
-     return gw_body_data_write(&data->body, buf, len, iseof);
+    if (data->args.sizelimit
+        && gw_body_data_size(&data->body) >= data->max_object_size) {
+        ci_debug_printf(2, "Object bigger than max scanable file. \n");
+
+    /*TODO: Raise an error report rather than just raise an error */
+    return CI_ERROR;
+    } 
+    ci_debug_printf(9, "gw_rebuild_read_from_net:Writing to data->body, %d bytes \n", len);
+
+    return gw_body_data_write(&data->body, buf, len, iseof);
 }
 
 static int gw_rebuild_io(char *wbuf, int *wlen, char *rbuf, int *rlen, int iseof, ci_request_t *req)
@@ -374,14 +368,14 @@ static int gw_rebuild_end_of_data_handler(ci_request_t *req)
 
     gw_rebuild_req_data_t *data = ci_service_data(req);
 
-    if (!data || data->body.type == GW_BT_NONE){
+    if (!data){
         data->gw_processing = GW_PROCESSING_NONE;
         ci_stat_uint64_inc(GW_UNPROCESSABLE, 1);                 
         return CI_MOD_DONE;
     }
 
     int rebuild_status = CI_ERROR;
-    rebuild_status = rebuild_request_body(req, data, data->body.store.file,data->body.rebuild);
+    rebuild_status = rebuild_request_body(req, data, data->body.store, data->body.rebuild);
     
     if (rebuild_status == CI_ERROR){
         int error_report_size;
@@ -389,7 +383,7 @@ static int gw_rebuild_end_of_data_handler(ci_request_t *req)
         error_report_size = ci_membuf_size(data->error_page);
    
         gw_body_data_destroy(&data->body);
-        gw_body_data_new(&data->body, GW_BT_MEM, error_report_size);
+        gw_body_data_new(&data->body, error_report_size);
         gw_body_data_write(&data->body, data->error_page->buf, error_report_size, 1);
         rebuild_content_length(req, &data->body);
     }
@@ -478,8 +472,8 @@ int rebuild_request_body(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simp
 
 int replace_request_body(gw_rebuild_req_data_t* data, ci_simple_file_t* rebuild)
 {
-    ci_simple_file_destroy(data->body.store.file);
-    data->body.store.file = rebuild;        
+    ci_simple_file_destroy(data->body.store);
+    data->body.store = rebuild;        
     return CI_OK;
 }
 
@@ -507,7 +501,7 @@ static int init_body_data(ci_request_t *req)
     gw_rebuild_req_data_t *data = ci_service_data(req);
     assert(data);
 
-    gw_body_data_new(&(data->body), GW_BT_FILE, data->args.sizelimit==0 ? 0 : data->max_object_size);
+    gw_body_data_new(&(data->body), data->args.sizelimit==0 ? 0 : data->max_object_size);
         /*Icap server can not send data at the begining.
         The following call does not needed because the c-icap
         does not send any data if the ci_req_unlock_data is not called:*/
@@ -516,9 +510,6 @@ static int init_body_data(ci_request_t *req)
         /* Let ci_simple_file api to control the percentage of data.
          For now no data can send */
     gw_body_data_lock_all(&(data->body));
-
-    if (data->body.type == GW_BT_NONE)           /*Memory allocation or something else ..... */
-        return CI_ERROR;
 
     return CI_OK;
 }
@@ -625,15 +616,10 @@ void rebuild_content_length(ci_request_t *req, gw_body_data_t *bd)
     ci_off_t new_file_size = 0;
     char buf[256];
     ci_simple_file_t *body = NULL;
-    ci_membuf_t *memBuf = NULL;
 
-    if (bd->type == GW_BT_FILE) {
-        body = bd->store.file;
-        assert(body->readpos == 0);
-        new_file_size = body->endpos;
-    }
-    else /*do nothing....*/
-        return;
+    body = bd->store;
+    assert(body->readpos == 0);
+    new_file_size = body->endpos;
 
     ci_debug_printf(5, "Body data size changed to new size %"  PRINTF_OFF_T "\n",
                     (CAST_OFF_T)new_file_size);

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.h
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.h
@@ -23,7 +23,6 @@ struct gw_file_types {
 typedef struct gw_rebuild_req_data {
     gw_body_data_t body;
     ci_request_t *req;
-    int must_scanned ;
     int allow204;
     int gw_status;                  /* used to record the Glasswall processing status   */
     int gw_processing;              /* Used to record whether Glasswall processing is required */

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.h
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.h
@@ -10,10 +10,10 @@
 /* Used to initialise gw_status */
 #define GW_STATUS_UNDEFINED 99
 
-enum {NO_DECISION = -1, NO_SCAN=0,SCAN};
+enum {NO_DECISION = -1, NO_SCAN=0, SCAN=1};
 
 /* Used to define the gw_processing content */
-enum {GW_PROCESSING_UNDEFINED = -1, GW_PROCESSING_NONE=0, GW_PROCESSING_SCANNED};
+enum {GW_PROCESSING_UNDEFINED = -1, GW_PROCESSING_NONE=0, GW_PROCESSING_SCANNED=1};
 
 struct gw_file_types {
     int *scantypes;


### PR DESCRIPTION
Closing issue #2 and #20 

Refactored the code to simplify the processing. Removed the option to use memory based storage in preference to file based storage, since all content needs to be saved to file anyway in order to be passed to the Proxy API App.

The process of simplifying the code has resolved the bug where some rebuilt  files we returned from the ICAP Server with the last byte missing.