### PR TITLE
Load RabbitMQ Credentials from environment.

### DIFF
--- a/cloud-proxy-app/source/AdaptationService/RabbitMqClient.cs
+++ b/cloud-proxy-app/source/AdaptationService/RabbitMqClient.cs
@@ -28,15 +28,30 @@ namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
             _responseProcessor = responseProcessor ?? throw new ArgumentNullException(nameof(responseProcessor));
             _queueConfiguration = queueConfiguration ?? throw new ArgumentNullException(nameof(queueConfiguration));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            CheckCredentials(queueConfiguration);
 
             _logger.LogInformation($"Setting up queue connection '{queueConfiguration.MBHostName}:{queueConfiguration.MBPort}'");
             connectionFactory = new ConnectionFactory()
             {
                 HostName = queueConfiguration.MBHostName,
                 Port = queueConfiguration.MBPort,
-                UserName = ConnectionFactory.DefaultUser,
-                Password = ConnectionFactory.DefaultPass
+                UserName = queueConfiguration.MBUsername,
+                Password = queueConfiguration.MBPassword
             };
+        }
+
+        private void CheckCredentials(IQueueConfiguration queueConfiguration)
+        {
+            if (string.IsNullOrEmpty(queueConfiguration.MBUsername))
+            {
+                queueConfiguration.MBUsername = ConnectionFactory.DefaultUser;
+                _logger.LogInformation("No RabbitMQ Username provided, using default");
+            }
+            if (string.IsNullOrEmpty(queueConfiguration.MBPassword))
+            {
+                queueConfiguration.MBPassword = ConnectionFactory.DefaultPass;
+                _logger.LogInformation("No RabbitMQ Password provided, using default");
+            }
         }
 
         public void Connect()

--- a/cloud-proxy-app/source/Configuration/IQueueConfiguration.cs
+++ b/cloud-proxy-app/source/Configuration/IQueueConfiguration.cs
@@ -2,6 +2,9 @@
 {
     public interface IQueueConfiguration
     {
+        public string MBUsername { get; set; }
+        public string MBPassword { get; set; }
+
         public string MBHostName { get; set; }
         public int MBPort { get; set; }
         public string ExchangeName { get; set; }

--- a/cloud-proxy-app/source/Configuration/RabbitMqQueueConfiguration.cs
+++ b/cloud-proxy-app/source/Configuration/RabbitMqQueueConfiguration.cs
@@ -2,6 +2,8 @@
 {
     public class RabbitMqQueueConfiguration : IQueueConfiguration
     {
+        public string MBUsername { get; set; }
+        public string MBPassword { get; set; }
         public string MBHostName { get; set; }
         public int MBPort { get; set; }
         public string ExchangeName { get; set; }

--- a/cloud-proxy-app/test/AdaptationService/RabbitMqClientTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/RabbitMqClientTests.cs
@@ -1,0 +1,64 @@
+﻿using Glasswall.IcapServer.CloudProxyApp.AdaptationService;
+using Glasswall.IcapServer.CloudProxyApp.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using RabbitMQ.Client;
+
+namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
+{
+    class RabbitMqClientTests
+    {
+        const string AnyMBHostname = "test hostname";
+        const int AnyMBPort = 1234;
+
+        IResponseProcessor mockResponseProcessor;
+        ILogger<RabbitMqClient<AdaptationOutcomeProcessor>> mockLogger;
+
+        Mock<IQueueConfiguration> mockQueueConfiguration;
+
+        [SetUp]
+        public void RabbitMqClientTestsSetup()
+        {
+            mockResponseProcessor = Mock.Of<IResponseProcessor>();
+            mockLogger = Mock.Of<ILogger<RabbitMqClient<AdaptationOutcomeProcessor>>>();
+            mockQueueConfiguration = new Mock<IQueueConfiguration>();
+            mockQueueConfiguration.SetupAllProperties();
+
+            mockQueueConfiguration.Object.MBHostName = AnyMBHostname;
+            mockQueueConfiguration.Object.MBPort = AnyMBPort;
+        }
+
+        [Test]
+        public void Missing_RabbitMQ_Credentials_Set_To_Defaults()
+        {
+            // Arrange
+            const string DefaultRabbitUser = ConnectionFactory.DefaultUser;
+            const string DefaultRabbitPassword = ConnectionFactory.DefaultPass;
+
+            // Act
+            _ = new RabbitMqClient<AdaptationOutcomeProcessor>(mockResponseProcessor, mockQueueConfiguration.Object, mockLogger);
+
+            // Assert
+            Assert.That(mockQueueConfiguration.Object.MBUsername, Is.EqualTo(DefaultRabbitUser), "With no specified username the default should be set");
+            Assert.That(mockQueueConfiguration.Object.MBPassword, Is.EqualTo(DefaultRabbitPassword), "With no specified password the default should be set");
+        }
+
+        [Test]
+        public void Provided_RabbitMQ_Credentials_Should_Be_Used()
+        {
+            // Arrange
+            const string ExpectedRabbitUser = "Rabbit User";
+            const string ExpectedRabbitPassword = "Rabbit Password";
+            mockQueueConfiguration.Object.MBUsername = ExpectedRabbitUser;
+            mockQueueConfiguration.Object.MBPassword = ExpectedRabbitPassword;
+
+            // Act
+            _ = new RabbitMqClient<AdaptationOutcomeProcessor>(mockResponseProcessor, mockQueueConfiguration.Object, mockLogger);
+
+            // Assert
+            Assert.That(mockQueueConfiguration.Object.MBUsername, Is.EqualTo(ExpectedRabbitUser), "Specified username should be used");
+            Assert.That(mockQueueConfiguration.Object.MBPassword, Is.EqualTo(ExpectedRabbitPassword), "Specified password should be used");
+        }
+    }
+}


### PR DESCRIPTION
 If missing, use default RabbitMQ Credentials