### PR TITLE
Separate processing status from function status 

### DIFF
--- a/c-icap-modules/services/gw_rebuild/gw_guid.c
+++ b/c-icap-modules/services/gw_rebuild/gw_guid.c
@@ -10,8 +10,8 @@ void generate_random_guid(unsigned char guid[40])
   srand (clock());
 
   int nLen = strlen (szTemp);
-
-  for (int t=0; t<nLen+1; t++){
+  int t;
+  for (t=0; t<nLen+1; t++){
     int r = rand () % 16;
     char c = ' ';   
 


### PR DESCRIPTION
This ensures that processing status is correctly returned in the ICAP Response