### PR TITLE
Use provided Error Report in the event of Rebuild Failure

### DIFF
--- a/c-icap-modules/services/gw_rebuild/gw_guid.c
+++ b/c-icap-modules/services/gw_rebuild/gw_guid.c
@@ -9,8 +9,8 @@ void generate_random_guid(unsigned char guid[40])
 {
   srand (clock());
 
-  int nLen = strlen (szTemp);
-  int t;
+  unsigned long nLen = strlen (szTemp);
+  unsigned long t;
   for (t=0; t<nLen+1; t++){
     int r = rand () % 16;
     char c = ' ';   

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -449,23 +449,21 @@ int rebuild_request_body(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simp
     /* Store the return status for inclusion in any error report */
     data->gw_status = gw_proxy_api_return;
     
-    int rebuild_status =  REBUILD_ERROR;
+    int rebuild_status = REBUILD_ERROR;
+    int outfile_status = CI_ERROR;
     switch (gw_proxy_api_return)
     {
         case GW_FAILED:
-            {
-                int outfile_status;
-                ci_debug_printf(3, "rebuild_request_body GW_FAILED:FileId:%s\n", data->file_id);
-                outfile_status = process_output_file(req, data, output);
+            ci_debug_printf(3, "rebuild_request_body GW_FAILED:FileId:%s\n", data->file_id);
+            outfile_status = process_output_file(req, data, output);
 
-                if (outfile_status == CI_OK){
-                    ci_stat_uint64_inc(GW_REBUILD_FAILURES, 1); 
-                    rebuild_status =  REBUILD_FAILED;
-                } else {
-                    ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
-                }
-                break;
-            }            
+            if (outfile_status == CI_OK){
+                ci_stat_uint64_inc(GW_REBUILD_FAILURES, 1); 
+                rebuild_status =  REBUILD_FAILED;
+            } else {
+                ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
+            }
+            break;
         case GW_ERROR:
             ci_debug_printf(3, "rebuild_request_body GW_ERROR:FileId:%s\n", data->file_id);
             ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
@@ -476,19 +474,16 @@ int rebuild_request_body(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simp
             rebuild_status = REBUILD_UNPROCESSED;
             break;
         case GW_REBUILT:
-            {
-                int outfile_status;
-                ci_debug_printf(3, "rebuild_request_body GW_REBUILT:FileId:%s\n", data->file_id);
-                outfile_status = process_output_file(req, data, output);
+            ci_debug_printf(3, "rebuild_request_body GW_REBUILT:FileId:%s\n", data->file_id);
+            outfile_status = process_output_file(req, data, output);
 
-                if (outfile_status == CI_OK){
-                    ci_stat_uint64_inc(GW_REBUILD_SUCCESSES, 1); 
-                    rebuild_status = REBUILD_REBUILT;    
-                } else {
-                    ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
-                }
-                break;  
-            }      
+            if (outfile_status == CI_OK){
+                ci_stat_uint64_inc(GW_REBUILD_SUCCESSES, 1); 
+                rebuild_status = REBUILD_REBUILT;    
+            } else {
+                ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
+            }
+            break;  
         default:
             ci_debug_printf(3, "Unrecognised Proxy API return value (%d):FileId:%s\n", gw_proxy_api_return, data->file_id);
             ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -56,7 +56,6 @@ static int GW_UNPROCESSABLE = -1;
 
 /*********************/
 /* Formating table   */
-static int fmt_gw_rebuild_http_url(ci_request_t *req, char *buf, int len, const char *param);
 static int fmt_gw_rebuild_fileid(ci_request_t *req, char *buf, int len, const char *param);
 
 struct ci_fmt_entry gw_rebuild_report_format_table [] = {

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -57,11 +57,10 @@ static int GW_UNPROCESSABLE = -1;
 /*********************/
 /* Formating table   */
 static int fmt_gw_rebuild_http_url(ci_request_t *req, char *buf, int len, const char *param);
-static int fmt_gw_rebuild_error_code(ci_request_t *req, char *buf, int len, const char *param);
+static int fmt_gw_rebuild_fileid(ci_request_t *req, char *buf, int len, const char *param);
 
 struct ci_fmt_entry gw_rebuild_report_format_table [] = {
-    {"%GU", "The HTTP url", fmt_gw_rebuild_http_url},
-    {"%GE", "The Error code", fmt_gw_rebuild_error_code},
+    {"%GI", "The file id blocked is", fmt_gw_rebuild_fileid},
     { NULL, NULL, NULL}
 };
 
@@ -731,16 +730,10 @@ static void add_file_id_header(ci_request_t *req, const char* header_key, unsign
 /**************************************************************/
 /* gw_rebuild templates  formating table                         */
 
-int fmt_gw_rebuild_http_url(ci_request_t *req, char *buf, int len, const char *param)
+static int fmt_gw_rebuild_fileid(ci_request_t *req, char *buf, int len, const char *param)
 {
     gw_rebuild_req_data_t *data = ci_service_data(req);
-    return snprintf(buf, len, "%s", data->url_log);
-}
-
-static int fmt_gw_rebuild_error_code(ci_request_t *req, char *buf, int len, const char *param)
-{
-    gw_rebuild_req_data_t *data = ci_service_data(req);
-    return snprintf(buf, len, "%d", data->gw_status);
+    return snprintf(buf, len, "%s", data->file_id);
 }
 
 char* concat(char* output, const char* s1, const char* s2)

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -357,14 +357,14 @@ static int gw_rebuild_io(char *wbuf, int *wlen, char *rbuf, int *rlen, int iseof
     strcat(printBuffer, "gw_rebuild_io, ");
 
     if (wlen) {
-        sprintf(tempBuffer, "wlen=%d, ", *wlen);
+        snprintf(tempBuffer, sizeof(tempBuffer), "wlen=%d, ", *wlen);
         strcat(printBuffer, tempBuffer);
     }
     if (rlen) {
-        sprintf(tempBuffer, "rlen=%d, ", *rlen);
+        snprintf(tempBuffer, sizeof(tempBuffer), "rlen=%d, ", *rlen);
         strcat(printBuffer, tempBuffer);
     }
-    sprintf(tempBuffer, "iseof=%d\n", iseof);
+    snprintf(tempBuffer, sizeof(tempBuffer), "iseof=%d\n", iseof);
     strcat(printBuffer, tempBuffer);
     ci_debug_printf(9, "%s", printBuffer);
 

--- a/c-icap-modules/services/gw_rebuild/templates/en-US/POLICY_ISSUE
+++ b/c-icap-modules/services/gw_rebuild/templates/en-US/POLICY_ISSUE
@@ -1,19 +1,17 @@
 <html>
  <head>
-   <title>Policy Issue</title>
+   <title>Processing Error</title>
 </head>
 
 <body>
-<h1>Document Access Blocked due to Policy</h1>
+<h1>Document Access Blocked due to Processing Error</h1>
 
 
-You tried to upload/download a file that does not comply with current policy
+A processing error has blocked access to a file you tried to upload/download
 <br>
-The Http location is:
-<b> %GU </b>
 <br>
-The error code is:
-<b> %GE </b>
+The file id blocked is:
+<b> %GI </b>
 <p>
   For more information contact your system administrator
 

--- a/c-icap-modules/services/gw_rebuild/templates/en/POLICY_ISSUE
+++ b/c-icap-modules/services/gw_rebuild/templates/en/POLICY_ISSUE
@@ -1,19 +1,17 @@
 <html>
  <head>
-   <title>Policy Issue</title>
+   <title>Processing Error</title>
 </head>
 
 <body>
-<h1>Document Access Blocked due to Policy</h1>
+<h1>Document Access Blocked due to Processing Error</h1>
 
 
-You tried to upload/download a file that does not comply with current policy
+A processing error has blocked access to a file you tried to upload/download
 <br>
-The Http location is:
-<b> %GU </b>
 <br>
-The error code is:
-<b> %GE </b>
+The file id blocked is:
+<b> %GI </b>
 <p>
   For more information contact your system administrator
 


### PR DESCRIPTION
Also modified ICAP generated error report, generated because of a processing error to be error specific rather than refer to policy blocking access to the file.

Fixed warnings raised in static file analysis.