### PR TITLE
Updated to return provided error report in the event of Rebuild Failure

### DIFF
--- a/c-icap-modules/services/gw_rebuild/gw_guid.c
+++ b/c-icap-modules/services/gw_rebuild/gw_guid.c
@@ -9,8 +9,8 @@ void generate_random_guid(unsigned char guid[40])
 {
   srand (clock());
 
-  int nLen = strlen (szTemp);
-  int t;
+  unsigned long nLen = strlen (szTemp);
+  unsigned long t;
   for (t=0; t<nLen+1; t++){
     int r = rand () % 16;
     char c = ' ';   

--- a/c-icap-modules/services/gw_rebuild/gw_rebuild.c
+++ b/c-icap-modules/services/gw_rebuild/gw_rebuild.c
@@ -23,8 +23,8 @@
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
-
-void generate_error_page(gw_rebuild_req_data_t *data, ci_request_t *req);
+static void generate_403_headers(ci_request_t *req);
+static void generate_error_page(gw_rebuild_req_data_t *data, ci_request_t *req);
 static void rebuild_content_length(ci_request_t *req, gw_body_data_t *body);
 static int file_exists (char *filename);
 /***********************************************************************************/
@@ -38,6 +38,8 @@ static const int GW_DISABLE_FILE_ID_REPORTING = 0;
 #define GW_VERSION_SIZE 15
 #define GW_BT_FILE_PATH_SIZE 150
 #define STATS_BUFFER 1024
+
+enum rebuild_request_body_return {REBUILD_UNPROCESSED=0, REBUILD_REBUILT=1, REBUILD_FAILED=2, REBUILD_ERROR=9};
 
 char *PROXY_APP_LOCATION = NULL;
 
@@ -54,12 +56,10 @@ static int GW_UNPROCESSABLE = -1;
 
 /*********************/
 /* Formating table   */
-static int fmt_gw_rebuild_http_url(ci_request_t *req, char *buf, int len, const char *param);
-static int fmt_gw_rebuild_error_code(ci_request_t *req, char *buf, int len, const char *param);
+static int fmt_gw_rebuild_fileid(ci_request_t *req, char *buf, int len, const char *param);
 
 struct ci_fmt_entry gw_rebuild_report_format_table [] = {
-    {"%GU", "The HTTP url", fmt_gw_rebuild_http_url},
-    {"%GE", "The Error code", fmt_gw_rebuild_error_code},
+    {"%GI", "The file id blocked is", fmt_gw_rebuild_fileid},
     { NULL, NULL, NULL}
 };
 
@@ -356,14 +356,14 @@ static int gw_rebuild_io(char *wbuf, int *wlen, char *rbuf, int *rlen, int iseof
     strcat(printBuffer, "gw_rebuild_io, ");
 
     if (wlen) {
-        sprintf(tempBuffer, "wlen=%d, ", *wlen);
+        snprintf(tempBuffer, sizeof(tempBuffer), "wlen=%d, ", *wlen);
         strcat(printBuffer, tempBuffer);
     }
     if (rlen) {
-        sprintf(tempBuffer, "rlen=%d, ", *rlen);
+        snprintf(tempBuffer, sizeof(tempBuffer), "rlen=%d, ", *rlen);
         strcat(printBuffer, tempBuffer);
     }
-    sprintf(tempBuffer, "iseof=%d\n", iseof);
+    snprintf(tempBuffer, sizeof(tempBuffer), "iseof=%d\n", iseof);
     strcat(printBuffer, tempBuffer);
     ci_debug_printf(9, "%s", printBuffer);
 
@@ -396,11 +396,16 @@ static int gw_rebuild_end_of_data_handler(ci_request_t *req)
         return CI_MOD_DONE;
     }
 
-    int rebuild_status = CI_ERROR;
+    int rebuild_status = REBUILD_ERROR;
     rebuild_status = rebuild_request_body(req, data, data->body.store, data->body.rebuild);
-    
-    if (rebuild_status == CI_ERROR){
+
+    if (rebuild_status == REBUILD_FAILED){
+        ci_debug_printf(3, "gw_rebuild_end_of_data_handler:FileId:%s, REBUILD_FAILED\n", data->file_id);
+        generate_403_headers(req);
+    } else if (rebuild_status == REBUILD_ERROR){
         int error_report_size;
+        ci_debug_printf(3, "gw_rebuild_end_of_data_handler:FileId:%s, REBUILD_ERROR\n", data->file_id);
+        generate_403_headers(req);
         generate_error_page(data, req);               
         error_report_size = ci_membuf_size(data->error_page);
    
@@ -415,7 +420,7 @@ static int gw_rebuild_end_of_data_handler(ci_request_t *req)
     }
 
     ci_debug_printf(3, "gw_rebuild_end_of_data_handler:FileId:%s, allow204(%d)\n", data->file_id, data->allow204);
-    if (data->allow204 && rebuild_status == CI_MOD_ALLOW204){
+    if (data->allow204 && rebuild_status == REBUILD_UNPROCESSED){
         ci_debug_printf(3, "gw_rebuild_end_of_data_handler:FileId:%s, returning %d\n",  data->file_id, rebuild_status);
         return CI_MOD_ALLOW204;
     }
@@ -431,9 +436,10 @@ static int process_output_file(ci_request_t *req, gw_rebuild_req_data_t* data, c
 static int replace_request_body(gw_rebuild_req_data_t* data, ci_simple_file_t* rebuild);
 static int refresh_externally_updated_file(ci_simple_file_t* updated_file);
 /* Return value:  */
-/* CI_OK - to continue to rebuilt content */
-/* CI_MOD_ALLOW204 - to continue to unchanged content */
-/* CI_ERROR - to report error, whether due to policy error or processing error */
+/* REBUILD_UNPROCESSED - to continue to unchanged content */
+/* REBUILD_REBUILT - to continue to rebuilt content */
+/* REBUILD_FAILED - to report error and use supplied error report */
+/* REBUILD_ERROR - to report  processing error */
 int rebuild_request_body(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simple_file_t* input, ci_simple_file_t* output)
 {
     ci_stat_uint64_inc(GW_SCAN_REQS, 1);    
@@ -443,22 +449,21 @@ int rebuild_request_body(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simp
     /* Store the return status for inclusion in any error report */
     data->gw_status = gw_proxy_api_return;
     
-    int ci_status =  CI_ERROR;
+    int rebuild_status = REBUILD_ERROR;
+    int outfile_status = CI_ERROR;
     switch (gw_proxy_api_return)
     {
         case GW_FAILED:
-            {
-                int outfile_status;
-                ci_debug_printf(3, "rebuild_request_body GW_FAILED:FileId:%s\n", data->file_id);
-                outfile_status = process_output_file(req, data, output);
+            ci_debug_printf(3, "rebuild_request_body GW_FAILED:FileId:%s\n", data->file_id);
+            outfile_status = process_output_file(req, data, output);
 
-                if (outfile_status == CI_OK){
-                    ci_stat_uint64_inc(GW_REBUILD_FAILURES, 1); 
-                } else {
-                    ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
-                }
-                break;
-            }            
+            if (outfile_status == CI_OK){
+                ci_stat_uint64_inc(GW_REBUILD_FAILURES, 1); 
+                rebuild_status =  REBUILD_FAILED;
+            } else {
+                ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
+            }
+            break;
         case GW_ERROR:
             ci_debug_printf(3, "rebuild_request_body GW_ERROR:FileId:%s\n", data->file_id);
             ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
@@ -466,23 +471,24 @@ int rebuild_request_body(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simp
         case GW_UNPROCESSED:
             ci_debug_printf(3, "rebuild_request_body GW_UNPROCESSED:FileId:%s\n", data->file_id);
             ci_stat_uint64_inc(GW_NOT_PROCESSED, 1); 
-            ci_status = CI_MOD_ALLOW204;
+            rebuild_status = REBUILD_UNPROCESSED;
             break;
         case GW_REBUILT:
             ci_debug_printf(3, "rebuild_request_body GW_REBUILT:FileId:%s\n", data->file_id);
-            ci_status = process_output_file(req, data, output);
+            outfile_status = process_output_file(req, data, output);
 
-            if (ci_status == CI_OK){
-                ci_stat_uint64_inc(GW_REBUILD_SUCCESSES, 1);     
+            if (outfile_status == CI_OK){
+                ci_stat_uint64_inc(GW_REBUILD_SUCCESSES, 1); 
+                rebuild_status = REBUILD_REBUILT;    
             } else {
                 ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
             }
-            break;        
+            break;  
         default:
             ci_debug_printf(3, "Unrecognised Proxy API return value (%d):FileId:%s\n", gw_proxy_api_return, data->file_id);
             ci_stat_uint64_inc(GW_REBUILD_ERRORS, 1); 
     }
-    return ci_status;    
+    return rebuild_status;    
 }
 
 static int process_output_file(ci_request_t *req, gw_rebuild_req_data_t* data, ci_simple_file_t* output)
@@ -550,12 +556,8 @@ static int init_body_data(ci_request_t *req)
     return CI_OK;
 }
 
-void generate_error_page(gw_rebuild_req_data_t *data, ci_request_t *req)
+static void generate_403_headers(ci_request_t *req)
 {
-    ci_membuf_t *error_page;
-    char buf[1024];
-    const char *lang;
-
     if ( ci_http_response_headers(req))
          ci_http_response_reset_headers(req);
     else
@@ -564,13 +566,20 @@ void generate_error_page(gw_rebuild_req_data_t *data, ci_request_t *req)
     ci_http_response_add_header(req, "Server: C-ICAP");
     ci_http_response_add_header(req, "Connection: close");
     ci_http_response_add_header(req, "Content-Type: text/html");
+}
+
+static void generate_error_page(gw_rebuild_req_data_t *data, ci_request_t *req)
+{
+    ci_membuf_t *error_page;
+    char buf[1024];
+    const char *lang;
 
     error_page = ci_txt_template_build_content(req, "gw_rebuild", "POLICY_ISSUE",
                            gw_rebuild_report_format_table);
 
     lang = ci_membuf_attr_get(error_page, "lang");
     if (lang) {
-        snprintf(buf, sizeof(buf), "content-language: %s", lang);
+        snprintf(buf, sizeof(buf), "Content-Language: %s", lang);
         buf[sizeof(buf)-1] = '\0';
         ci_http_response_add_header(req, buf);
     }
@@ -715,16 +724,10 @@ static void add_file_id_header(ci_request_t *req, const char* header_key, unsign
 /**************************************************************/
 /* gw_rebuild templates  formating table                         */
 
-int fmt_gw_rebuild_http_url(ci_request_t *req, char *buf, int len, const char *param)
+static int fmt_gw_rebuild_fileid(ci_request_t *req, char *buf, int len, const char *param)
 {
     gw_rebuild_req_data_t *data = ci_service_data(req);
-    return snprintf(buf, len, "%s", data->url_log);
-}
-
-static int fmt_gw_rebuild_error_code(ci_request_t *req, char *buf, int len, const char *param)
-{
-    gw_rebuild_req_data_t *data = ci_service_data(req);
-    return snprintf(buf, len, "%d", data->gw_status);
+    return snprintf(buf, len, "%s", data->file_id);
 }
 
 char* concat(char* output, const char* s1, const char* s2)

--- a/c-icap-modules/services/gw_rebuild/templates/en-US/POLICY_ISSUE
+++ b/c-icap-modules/services/gw_rebuild/templates/en-US/POLICY_ISSUE
@@ -1,19 +1,17 @@
 <html>
  <head>
-   <title>Policy Issue</title>
+   <title>Processing Error</title>
 </head>
 
 <body>
-<h1>Document Access Blocked due to Policy</h1>
+<h1>Document Access Blocked due to Processing Error</h1>
 
 
-You tried to upload/download a file that does not comply with current policy
+A processing error has blocked access to a file you tried to upload/download
 <br>
-The Http location is:
-<b> %GU </b>
 <br>
-The error code is:
-<b> %GE </b>
+The file id blocked is:
+<b> %GI </b>
 <p>
   For more information contact your system administrator
 

--- a/c-icap-modules/services/gw_rebuild/templates/en/POLICY_ISSUE
+++ b/c-icap-modules/services/gw_rebuild/templates/en/POLICY_ISSUE
@@ -1,19 +1,17 @@
 <html>
  <head>
-   <title>Policy Issue</title>
+   <title>Processing Error</title>
 </head>
 
 <body>
-<h1>Document Access Blocked due to Policy</h1>
+<h1>Document Access Blocked due to Processing Error</h1>
 
 
-You tried to upload/download a file that does not comply with current policy
+A processing error has blocked access to a file you tried to upload/download
 <br>
-The Http location is:
-<b> %GU </b>
 <br>
-The error code is:
-<b> %GE </b>
+The file id blocked is:
+<b> %GI </b>
 <p>
   For more information contact your system administrator
 


### PR DESCRIPTION
Additionally
Modified ICAP generated error report to be error specific

_Resolved static analysis issues_
Removed the use of the insecure "sprintf" function
Change variable types to match function return type
Remove unused function prototype.
Removal of nested sections