### PR TITLE
Loading of C-ICAP and gw_rebuild configuration from ConfigMap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ COPY --from=build /usr/local/c-icap /usr/local/c-icap
 COPY --from=build /run/c-icap /run/c-icap
 COPY --from=dotnet-builder /src/cloud-proxy-app/source/bin/Release/netcoreapp3.1/publish /usr/local/bin
 
+ADD ./opt /opt
+RUN chmod +x /opt/start.sh; sync
 EXPOSE 1344
 EXPOSE 1345
-CMD ["/usr/local/c-icap/bin/c-icap","-N","-D"]
+CMD /opt/start.sh

--- a/opt/start.sh
+++ b/opt/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# copy across mounted configuration files and start c-icap service
+echo "INFO: Copying across mounted configuration"
+cp -t /usr/local/c-icap/etc /usr/local/c-icap/conf/c-icap.conf /usr/local/c-icap/gw-rebuid-conf/gw_rebuild.conf
+
+sleep 5
+echo "INFO: Starting up C-ICAP service"
+/usr/local/c-icap/bin/c-icap -N -D

--- a/opt/start.sh
+++ b/opt/start.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 # copy across mounted configuration files and start c-icap service
-echo "INFO: Copying across mounted configuration"
-cp -t /usr/local/c-icap/etc /usr/local/c-icap/conf/c-icap.conf /usr/local/c-icap/gw-rebuid-conf/gw_rebuild.conf
 
-sleep 5
+MOUNTEDFILE=/usr/local/c-icap/conf/c-icap.conf
+if [ -f "$MOUNTEDFILE" ]; then
+	echo "INFO: Copying across mounted configuration"
+	cp -t /usr/local/c-icap/etc /usr/local/c-icap/conf/c-icap.conf /usr/local/c-icap/rebuild/gw_rebuild.conf
+else
+	echo "WARNING: No mounted configuration found, running with defaults"
+fi
+
+sleep 1
 echo "INFO: Starting up C-ICAP service"
 /usr/local/c-icap/bin/c-icap -N -D


### PR DESCRIPTION
The changes in this repo work in conjunction with updates being made in the 'icap-infrastructure' repo.
The process works with the Helm chart mounting the configuration into folders on the ICAP Server pod. When the docker container is started, it copies the mounted files from the landing folders into the `c-icap/etc` folder from which the executable reads its configuration.
This PR adds a script that is run when the Docker container starts. The script copies the files across before starting the ICAP Server.
If the configuration hasn't been mounted, then the ICAP Server will run with the default configuration that it was installed with.