### PR TITLE
feat [ICAP RESP]: Include server IP as an ICAP response header

### DIFF
--- a/c-icap/configure.ac
+++ b/c-icap/configure.ac
@@ -42,7 +42,7 @@ dnl Checks for OS specific flags and posix threads libraries.....
 
 case "$host_os" in
      linux*)
-	CFLAGS="-D_REENTRANT $CFLAGS"
+	CFLAGS="-D_REENTRANT -DGLASSWALL_HEADER $CFLAGS"
 	THREADS_LDADD="-lpthread"
 	THREADS_LDFLAGS=""
      ;;

--- a/c-icap/include/util.h
+++ b/c-icap/include/util.h
@@ -34,6 +34,9 @@ CI_DECLARE_FUNC(void) ci_strtime_rfc822(char *buf);
 CI_DECLARE_FUNC(int)  ci_mktemp_file(char*dir,char *name_template,char *filename);
 CI_DECLARE_FUNC(int)  ci_usleep(unsigned long usec);
 
+#ifdef GLASSWALL_HEADER
+CI_DECLARE_FUNC(int)  ci_getIpv4Addr(char *addr);
+#endif /* GLASSWALL_HEADER */
 
 #ifdef _WIN32
 CI_DECLARE_FUNC(int) mkstemp(char *filename);

--- a/c-icap/info.c
+++ b/c-icap/info.c
@@ -27,6 +27,10 @@
 #include "proc_threads_queues.h"
 #include "debug.h"
 
+#ifdef GLASSWALL_HEADER
+#include "util.h"
+#endif /* GLASSWALL_HEADER */
+
 int info_init_service(ci_service_xdata_t * srv_xdata,
                       struct ci_server_conf *server_conf);
 int info_check_preview_handler(char *preview_data, int preview_data_len,
@@ -141,6 +145,10 @@ int info_check_preview_handler(char *preview_data, int preview_data_len,
                                ci_request_t * req)
 {
     struct info_req_data *info_data = ci_service_data(req);
+#ifdef GLASSWALL_HEADER
+    char buf[MAX_HEADER_SIZE + 1];
+    char ipaddr[INET_ADDRSTRLEN + 1];
+#endif /* GLASSWALL_HEADER */
 
     if (ci_req_hasbody(req))
         return CI_MOD_ALLOW204;
@@ -151,6 +159,17 @@ int info_check_preview_handler(char *preview_data, int preview_data_len,
 
     ci_http_response_add_header(req, "HTTP/1.0 200 OK");
     ci_http_response_add_header(req, "Server: C-ICAP");
+
+#ifdef GLASSWALL_HEADER
+    memset (buf, 0x00, sizeof(buf));
+    memset (ipaddr, 0x00, sizeof(ipaddr));
+    if (!ci_getIpv4Addr (ipaddr))
+    {
+        snprintf(buf, MAX_HEADER_SIZE, "IP Address: %s", ipaddr);
+        buf[MAX_HEADER_SIZE] = '\0';
+        ci_http_response_add_header(req, buf);
+    }
+#endif /* GLASSWALL_HEADER */
     ci_http_response_add_header(req, "Content-Type: text/html");
     ci_http_response_add_header(req, "Content-Language: en");
     ci_http_response_add_header(req, "Connection: close");

--- a/c-icap/request.c
+++ b/c-icap/request.c
@@ -37,7 +37,6 @@
 #include "stats.h"
 #include "body.h"
 
-
 extern int TIMEOUT;
 extern int KEEPALIVE_TIMEOUT;
 extern const char *DEFAULT_SERVICE;
@@ -628,6 +627,10 @@ static void ec_responce_simple(ci_request_t * req, int ec)
 static int ec_responce(ci_request_t * req, int ec)
 {
     char buf[256];
+#ifdef GLASSWALL_HEADER
+    char ipaddr[INET_ADDRSTRLEN + 1];
+#endif /* GLASSWALL_HEADER */
+
     ci_service_xdata_t *srv_xdata = NULL;
     int len, allow204to200OK = 0;
     if (req->current_service_mod)
@@ -642,6 +645,17 @@ static int ec_responce(ci_request_t * req, int ec)
              ci_error_code(ec), ci_error_code_string(ec));
     ci_headers_add(req->response_header, buf);
     ci_headers_add(req->response_header, "Server: C-ICAP/" VERSION);
+#ifdef GLASSWALL_HEADER
+    memset (buf, 0x00, sizeof(buf));
+    memset (ipaddr, 0x00, sizeof(ipaddr));
+    if (!ci_getIpv4Addr (ipaddr))
+    {
+        snprintf(buf, 256, "IP Address: %s", ipaddr);
+        buf[255] = '\0';
+        ci_headers_add(req->response_header, buf);
+    }
+#endif /* GLASSWALL_HEADER */
+
     if (req->keepalive)
         ci_headers_add(req->response_header, "Connection: keep-alive");
     else
@@ -1164,6 +1178,9 @@ static void options_responce(ci_request_t * req)
     int preview, allow204, allow206, max_conns, xlen;
     int hastransfer = 0;
     int ttl;
+#ifdef GLASSWALL_HEADER
+    char ipaddr[INET_ADDRSTRLEN + 1];
+#endif /* GLASSWALL_HEADER */
     req->return_code = EC_200;
     head = req->response_header;
     srv_xdata = service_data(req->current_service_mod);
@@ -1191,6 +1208,16 @@ static void options_responce(ci_request_t * req)
     buf[MAX_HEADER_SIZE] = '\0';
     ci_headers_add(head, buf);
 
+#ifdef GLASSWALL_HEADER
+    memset (buf, 0x00, sizeof(buf));
+    memset (ipaddr, 0x00, sizeof(ipaddr));
+    if (!ci_getIpv4Addr (ipaddr))
+    {
+        snprintf(buf, MAX_HEADER_SIZE, "IP Address: %s", ipaddr);
+        buf[MAX_HEADER_SIZE] = '\0';
+        ci_headers_add(head, buf);
+    }
+#endif /* GLASSWALL_HEADER */
     ci_service_data_read_lock(srv_xdata);
     ci_headers_add(head, srv_xdata->ISTag);
     if (srv_xdata->TransferPreview[0] != '\0' && srv_xdata->preview_size >= 0) {


### PR DESCRIPTION
for review
https://github.com/k8-proxy/icap-infrastructure/issues/28
I've defined GLASSWALL_HEADER on autoconf.ac and if we remove this define, then the original source won't effected.