### PR TITLE
Retrieval of outcome-header properties from Adaptation-Outcome

### DIFF
--- a/cloud-proxy-app/source/AdaptationService/IHeaderFilter.cs
+++ b/cloud-proxy-app/source/AdaptationService/IHeaderFilter.cs
@@ -2,7 +2,7 @@
 
 namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
 {
-    interface IHeaderFilter
+    public interface IHeaderFilter
     {
         IDictionary<string, string> Extract(IDictionary<string, object> headers);
     }

--- a/cloud-proxy-app/source/AdaptationService/IHeaderFilter.cs
+++ b/cloud-proxy-app/source/AdaptationService/IHeaderFilter.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
+{
+    interface IHeaderFilter
+    {
+        IDictionary<string, string> Extract(IDictionary<string, object> headers);
+    }
+}

--- a/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
+++ b/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
@@ -6,6 +7,12 @@ namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
     public class OutcomeHeaderFilter : IHeaderFilter
     {
         const string OutcomeHeaderKeyRoot = "outcome-header";
+        private readonly ILogger<OutcomeHeaderFilter> logger;
+
+        public OutcomeHeaderFilter(ILogger<OutcomeHeaderFilter> logger)
+        {
+            this.logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+        }
 
         public IDictionary<string, string> Extract(IDictionary<string, object> headers)
         {
@@ -16,6 +23,11 @@ namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
             {
                 var strippedKey = item.Key.Remove(0, OutcomeHeaderKeyRoot.Length + 1);
                 var valueString = item.Value as string;
+                if (string.IsNullOrEmpty(valueString))
+                {
+                    logger.LogWarning($"FileId:{headers["file-id"]}: Invalid outcome header value for {item.Key} ");
+                    continue;
+                }
                 returnStore.Add(strippedKey, valueString);
             }
 

--- a/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
+++ b/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
+{
+    public class OutcomeHeaderFilter : IHeaderFilter
+    {
+        public IDictionary<string, string> Extract(IDictionary<string, object> headers)
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+}

--- a/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
+++ b/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
@@ -1,17 +1,22 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
 {
     public class OutcomeHeaderFilter : IHeaderFilter
     {
+        const string OutcomeHeaderKeyRoot = "outcome-header";
+
         public IDictionary<string, string> Extract(IDictionary<string, object> headers)
         {
-            var headerKey = "outcome-header-first-header";
+            var outcomeHeaders = headers.Where(h => h.Key.StartsWith(OutcomeHeaderKeyRoot)).ToDictionary(p => p.Key, p => p.Value); 
             var returnStore =  new Dictionary<string, string>();
-
-            if (headers.ContainsKey(headerKey))
+            
+            foreach (var item in outcomeHeaders)
             {
-                returnStore.Add("first-header", headers[headerKey] as string);
+                var strippedKey = item.Key.Remove(0, OutcomeHeaderKeyRoot.Length + 1);
+                var valueString = item.Value as string;
+                returnStore.Add(strippedKey, valueString);
             }
 
             return returnStore;

--- a/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
+++ b/cloud-proxy-app/source/AdaptationService/OutcomeHeaderFilter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
 {
@@ -7,7 +6,15 @@ namespace Glasswall.IcapServer.CloudProxyApp.AdaptationService
     {
         public IDictionary<string, string> Extract(IDictionary<string, object> headers)
         {
-            return new Dictionary<string, string>();
+            var headerKey = "outcome-header-first-header";
+            var returnStore =  new Dictionary<string, string>();
+
+            if (headers.ContainsKey(headerKey))
+            {
+                returnStore.Add("first-header", headers[headerKey] as string);
+            }
+
+            return returnStore;
         }
     }
 }

--- a/cloud-proxy-app/source/Setup/ServiceCollectionExtensionMethods.cs
+++ b/cloud-proxy-app/source/Setup/ServiceCollectionExtensionMethods.cs
@@ -33,6 +33,7 @@ namespace Glasswall.IcapServer.CloudProxyApp.Setup
 
             serviceCollection.AddTransient(typeof(IAdaptationServiceClient<>), typeof(RabbitMqClient<>));
             serviceCollection.AddTransient<IResponseProcessor, AdaptationOutcomeProcessor>();
+            serviceCollection.AddTransient<IHeaderFilter, OutcomeHeaderFilter>();
 
             return serviceCollection;
         }

--- a/cloud-proxy-app/test/AdaptationService/AdaptationOutcomeProcessorTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/AdaptationOutcomeProcessorTests.cs
@@ -9,12 +9,21 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
 {
     public class AdaptationOutcomeProcessorTests
     {
+        AdaptationOutcomeProcessor processor;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var mockHeaderFilter = new Mock<IHeaderFilter>();
+            mockHeaderFilter.Setup(m => m.Extract(It.IsAny<IDictionary<string, object>>()))
+                .Returns((IDictionary<string, object> i) => new Dictionary<string, string>());
+            processor = new AdaptationOutcomeProcessor(Mock.Of<ILogger<AdaptationOutcomeProcessor>>(), mockHeaderFilter.Object);
+        }
+
         [Test]
         public void Replace_Return_Rebuilt_Outcome()
         {
-
             // Arrange
-            var processor = new AdaptationOutcomeProcessor(Mock.Of<ILogger<AdaptationOutcomeProcessor>>());
             IDictionary<string, object> headerMap = new Dictionary<string, object>
                     {
                         { "file-id", Encoding.UTF8.GetBytes("737ba1cc-492c-4292-9a2c-fc7bfc722dc6") },
@@ -32,7 +41,6 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         public void Unmodified_Return_Unprocessed_Outcome()
         {
             // Arrange
-            var processor = new AdaptationOutcomeProcessor(Mock.Of<ILogger<AdaptationOutcomeProcessor>>());
             IDictionary<string, object> headerMap = new Dictionary<string, object>
                     {
                         { "file-id", Encoding.UTF8.GetBytes("737ba1cc-492c-4292-9a2c-fc7bfc722dc6") },
@@ -50,7 +58,6 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         public void Failed_Return_Failed_Outcome()
         {
             // Arrange
-            var processor = new AdaptationOutcomeProcessor(Mock.Of<ILogger<AdaptationOutcomeProcessor>>());
             IDictionary<string, object> headerMap = new Dictionary<string, object>
                     {
                         { "file-id", Encoding.UTF8.GetBytes("737ba1cc-492c-4292-9a2c-fc7bfc722dc6") },
@@ -68,7 +75,6 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         public void Incorrect_Message_Error_Outcome()
         {
             // Arrange
-            var processor = new AdaptationOutcomeProcessor(Mock.Of<ILogger<AdaptationOutcomeProcessor>>());
             IDictionary<string, object> headerMap = new Dictionary<string, object>();
 
             // Act
@@ -77,7 +83,5 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
             // Assert
             Assert.That(result, Is.EqualTo(ReturnOutcome.GW_ERROR), "expected the outcome to be 'error'");
         }
-
-
     }
 }

--- a/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using Glasswall.IcapServer.CloudProxyApp.AdaptationService;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using System;
@@ -9,21 +10,24 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
     public class OutcomeHeaderFilterTests
     {
         Dictionary<string, object> properties;
+        Mock<ILogger<OutcomeHeaderFilter>> mockLogger;
+        OutcomeHeaderFilter outcomeHeaderFilter;
 
         [SetUp]
         public void Init()
         {
             properties = new Dictionary<string, object>();
+            mockLogger = new Mock<ILogger<OutcomeHeaderFilter>>();
+            outcomeHeaderFilter = new OutcomeHeaderFilter(mockLogger.Object);
         }
 
         [Test]
         public void Empty_Dictionary_If_No_Properties()
         {
             // Arrange
-            var filter = new OutcomeHeaderFilter();
 
             // Act
-            var output = filter.Extract(properties);
+            var output = outcomeHeaderFilter.Extract(properties);
 
             // Assert
             Assert.That(output, Is.Empty, "Outcome Header filter should return an empty list of headers if the input is empty");
@@ -33,11 +37,10 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         public void Empty_Dictionary_If_No_Outcome_Headers()
         {
             // Arrange
-            var filter = new OutcomeHeaderFilter();
             AddStandardProperties(properties);
        
             // Act
-            var output = filter.Extract(properties);
+            var output = outcomeHeaderFilter.Extract(properties);
 
             // Assert
             Assert.That(output, Is.Empty, "Outcome Header filter should return an empty list of headers if the input only has unrelated properties");
@@ -46,15 +49,13 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         [Test]
         public void Single_Header_Is_Returned()
         {
-            var filter = new OutcomeHeaderFilter();
             AddStandardProperties(properties);
             properties.Add("outcome-header-first-header", "First Header Value");
    
             // Act
-            var output = filter.Extract(properties);
+            var output = outcomeHeaderFilter.Extract(properties);
 
             // Assert
-
             Assert.That(output.Count, Is.EqualTo(1), "Outcome Header filter should return a single outcome-header entry");
             Assert.That(output, Contains.Key("first-header"), "Outcome Header filter extract the correct key");
             Assert.That(output["first-header"], Is.EqualTo("First Header Value"), "Outcome Header filter should extract the matching value");
@@ -63,19 +64,45 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         [Test]
         public void Multiple_Headers_Are_Returned()
         {
-            var filter = new OutcomeHeaderFilter();
             AddStandardProperties(properties);
             properties.Add("outcome-header-first-header", "First Header Value");
             properties.Add("outcome-header-second-header", "Second Header Value");
 
             // Act
-            var output = filter.Extract(properties);
+            var output = outcomeHeaderFilter.Extract(properties);
 
             // Assert
-
             Assert.That(output.Count, Is.EqualTo(2), "Outcome Header filter should return both outcome-header entries");
             Assert.That(output, Contains.Key("second-header"), "Outcome Header filter extract the correct second key");
             Assert.That(output["second-header"], Is.EqualTo("Second Header Value"), "Outcome Header filter should extract the matching second value");
+        }
+
+        [Test]
+        public void Numerical_Values_Not_Permitted_In_OutcomeHeaders()
+        {
+            var answer = 42;
+            AddStandardProperties(properties);
+            properties.Add("outcome-header-numeric-header", answer);
+
+            // Act
+            var output = outcomeHeaderFilter.Extract(properties);
+
+            // Assert
+            Assert.That(output.Count, Is.EqualTo(0), "Outcome Header filter should not return numerical entry value");
+        }
+
+        [Test]
+        public void Invalid_Header_String_Not_Included([Values("", null)] string invalidValue)
+        {
+            AddStandardProperties(properties);
+            properties.Add("outcome-header-first-header", "Valid Header Value");
+            properties.Add("outcome-header-second-header", invalidValue);
+
+            // Act
+            var output = outcomeHeaderFilter.Extract(properties);
+
+            // Assert
+            Assert.That(output.Count, Is.EqualTo(1), "Outcome Header filter should return only valid header string values");
         }
 
         private void AddStandardProperties(IDictionary<string, object> properties)

--- a/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
@@ -60,6 +60,24 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
             Assert.That(output["first-header"], Is.EqualTo("First Header Value"), "Outcome Header filter should extract the matching value");
         }
 
+        [Test]
+        public void Multiple_Headers_Are_Returned()
+        {
+            var filter = new OutcomeHeaderFilter();
+            AddStandardProperties(properties);
+            properties.Add("outcome-header-first-header", "First Header Value");
+            properties.Add("outcome-header-second-header", "Second Header Value");
+
+            // Act
+            var output = filter.Extract(properties);
+
+            // Assert
+
+            Assert.That(output.Count, Is.EqualTo(2), "Outcome Header filter should return both outcome-header entries");
+            Assert.That(output, Contains.Key("second-header"), "Outcome Header filter extract the correct second key");
+            Assert.That(output["second-header"], Is.EqualTo("Second Header Value"), "Outcome Header filter should extract the matching second value");
+        }
+
         private void AddStandardProperties(IDictionary<string, object> properties)
         {
             properties.Add("file-id", Guid.NewGuid());

--- a/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
@@ -1,0 +1,24 @@
+﻿using Glasswall.IcapServer.CloudProxyApp.AdaptationService;
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
+{
+    public class OutcomeHeaderFilterTests
+    {
+        [Test]
+        public void Empty_Dictionary_If_No_Outcome_Headers()
+        {
+            // Arrange
+            var filter = new OutcomeHeaderFilter();
+
+            // Act
+            var output = filter.Extract(new Dictionary<string, object>());
+
+            // Assert
+            Assert.That(output, Is.Empty, "Outcome HEader filter should return an empty list of headers if the input is empty");
+
+        }
+    }
+}

--- a/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
@@ -8,6 +8,14 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
 {
     public class OutcomeHeaderFilterTests
     {
+        Dictionary<string, object> properties;
+
+        [SetUp]
+        public void Init()
+        {
+            properties = new Dictionary<string, object>();
+        }
+
         [Test]
         public void Empty_Dictionary_If_No_Properties()
         {
@@ -15,7 +23,7 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
             var filter = new OutcomeHeaderFilter();
 
             // Act
-            var output = filter.Extract(new Dictionary<string, object>());
+            var output = filter.Extract(properties);
 
             // Assert
             Assert.That(output, Is.Empty, "Outcome Header filter should return an empty list of headers if the input is empty");
@@ -26,12 +34,8 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         {
             // Arrange
             var filter = new OutcomeHeaderFilter();
-            var properties = new Dictionary<string, object>()
-            {
-                { "file-id", Guid.NewGuid() },
-                { "file-outcome", "replace"}
-            };
-
+            AddStandardProperties(properties);
+       
             // Act
             var output = filter.Extract(properties);
 
@@ -43,13 +47,9 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
         public void Single_Header_Is_Returned()
         {
             var filter = new OutcomeHeaderFilter();
-            var properties = new Dictionary<string, object>()
-            {
-                { "file-id", Guid.NewGuid() },
-                { "file-outcome", "replace"},
-                { "outcome-header-first-header", "First Header Value" }
-            };
-
+            AddStandardProperties(properties);
+            properties.Add("outcome-header-first-header", "First Header Value");
+   
             // Act
             var output = filter.Extract(properties);
 
@@ -58,6 +58,12 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
             Assert.That(output.Count, Is.EqualTo(1), "Outcome Header filter should return a single outcome-header entry");
             Assert.That(output, Contains.Key("first-header"), "Outcome Header filter extract the correct key");
             Assert.That(output["first-header"], Is.EqualTo("First Header Value"), "Outcome Header filter should extract the matching value");
+        }
+
+        private void AddStandardProperties(IDictionary<string, object> properties)
+        {
+            properties.Add("file-id", Guid.NewGuid());
+            properties.Add("file-outcome", "replace");
         }
     }
 }

--- a/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
@@ -38,5 +38,26 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
             // Assert
             Assert.That(output, Is.Empty, "Outcome Header filter should return an empty list of headers if the input only has unrelated properties");
         }
+
+        [Test]
+        public void Single_Header_Is_Returned()
+        {
+            var filter = new OutcomeHeaderFilter();
+            var properties = new Dictionary<string, object>()
+            {
+                { "file-id", Guid.NewGuid() },
+                { "file-outcome", "replace"},
+                { "outcome-header-first-header", "First Header Value" }
+            };
+
+            // Act
+            var output = filter.Extract(properties);
+
+            // Assert
+
+            Assert.That(output.Count, Is.EqualTo(1), "Outcome Header filter should return a single outcome-header entry");
+            Assert.That(output, Contains.Key("first-header"), "Outcome Header filter extract the correct key");
+            Assert.That(output["first-header"], Is.EqualTo("First Header Value"), "Outcome Header filter should extract the matching value");
+        }
     }
 }

--- a/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
+++ b/cloud-proxy-app/test/AdaptationService/OutcomeHeaderFilterTests.cs
@@ -1,6 +1,7 @@
 ﻿using Glasswall.IcapServer.CloudProxyApp.AdaptationService;
 using Moq;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 
 namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
@@ -8,7 +9,7 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
     public class OutcomeHeaderFilterTests
     {
         [Test]
-        public void Empty_Dictionary_If_No_Outcome_Headers()
+        public void Empty_Dictionary_If_No_Properties()
         {
             // Arrange
             var filter = new OutcomeHeaderFilter();
@@ -17,8 +18,25 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.AdaptationService
             var output = filter.Extract(new Dictionary<string, object>());
 
             // Assert
-            Assert.That(output, Is.Empty, "Outcome HEader filter should return an empty list of headers if the input is empty");
+            Assert.That(output, Is.Empty, "Outcome Header filter should return an empty list of headers if the input is empty");
+        }
 
+        [Test]
+        public void Empty_Dictionary_If_No_Outcome_Headers()
+        {
+            // Arrange
+            var filter = new OutcomeHeaderFilter();
+            var properties = new Dictionary<string, object>()
+            {
+                { "file-id", Guid.NewGuid() },
+                { "file-outcome", "replace"}
+            };
+
+            // Act
+            var output = filter.Extract(properties);
+
+            // Assert
+            Assert.That(output, Is.Empty, "Outcome Header filter should return an empty list of headers if the input only has unrelated properties");
         }
     }
 }

--- a/cloud-proxy-app/test/Setup/ServiceCollectionExtentionMethodsTests.cs
+++ b/cloud-proxy-app/test/Setup/ServiceCollectionExtentionMethodsTests.cs
@@ -1,4 +1,5 @@
-﻿using Glasswall.IcapServer.CloudProxyApp.Configuration;
+﻿using Glasswall.IcapServer.CloudProxyApp.AdaptationService;
+using Glasswall.IcapServer.CloudProxyApp.Configuration;
 using Glasswall.IcapServer.CloudProxyApp.Setup;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -91,6 +92,22 @@ namespace Glasswall.IcapServer.CloudProxyApp.Tests.Setup
             // Assert
             Assert.That(queueConfiguration, Is.Not.Null, "expected the object to be available");
             Assert.AreSame(queueConfiguration, secondQueueConfiguration, "expected the same object to be provided");
+        }
+
+        [Test]
+        public void OutcomeHeaderFilter_is_added_as_transitory()
+        {
+            // Arrange
+            IConfiguration configuration = _configurationBuilder.Build();
+
+            // Act
+            var serviceProvider = _serviceCollection.ConfigureServices(configuration).BuildServiceProvider(true);
+            var outcomeHeaderFilter = serviceProvider.GetService<IHeaderFilter>();
+            var secondOutcomeHeaderFilter = serviceProvider.GetService<IHeaderFilter>();
+
+            // Assert
+            Assert.That(outcomeHeaderFilter, Is.Not.Null, "expected the object to be available");
+            Assert.AreNotSame(outcomeHeaderFilter, secondOutcomeHeaderFilter, "don't expect the same object to be provided");
         }
 
         [Test]


### PR DESCRIPTION
First stage of updates to retrieve the properties prefixed with `outcome-header` from the `adaptation-outcome` response message.