### PR TITLE
Force Autotools files and shell scripts to have linux EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 text eol=lf
+*.sh     -lf  
+*.ac     -lf 
+*.am     -lf


### PR DESCRIPTION
Updating the .gitattributes file will ensure that the line endings of these files remain in Linux form <LF> without them being changed when cloned to Windows <CRLF> .